### PR TITLE
range end exclusive so add 1 to range

### DIFF
--- a/ArcGeekCalculator/scripts/coordinate_algorithm.py
+++ b/ArcGeekCalculator/scripts/coordinate_algorithm.py
@@ -215,7 +215,7 @@ class CoordinateCalculatorAlgorithm(QgsProcessingAlgorithm):
                         break
                     
                     start = i
-                    end = min(i + batch_size, total_features)
+                    end = min(i + batch_size, total_features+1)
                     
                     attr_map = {}
                     feature_ids = list(range(start, end))  # Convert range to list


### PR DESCRIPTION
Simple fix for #2 

range(start, stop[, step]) -> range object

Return an object that produces a sequence of integers from start (inclusive)
to stop **(exclusive**) by step. range(i, j) produces i, i+1, i+2, ..., j-1.
start defaults to 0, and stop is omitted! range(4) produces 0, 1, 2, 3.
These are exactly the valid indices for a list of 4 elements.
When step is given, it specifies the increment (or decrement).